### PR TITLE
Set Executor to 1

### DIFF
--- a/examples/nodejs/image/Dockerfile
+++ b/examples/nodejs/image/Dockerfile
@@ -1,4 +1,4 @@
 FROM gcr.io/google_appengine/nodejs
 ADD swarm-client.jar /lib/
 RUN apt-get -y update && apt-get -y install git openjdk-7-jre  openjdk-7-jdk wget libpng-dev && apt-get clean
-ENTRYPOINT ["java", "-jar", "/lib/swarm-client.jar", "-disableSslVerification", "-master", "http://jenkins:8080", "-labels", "nodejs-slave"]
+ENTRYPOINT ["java", "-jar", "/lib/swarm-client.jar", "-disableSslVerification", "-master", "http://jenkins:8080", "-labels", "nodejs-slave", "-executors", "1"]

--- a/examples/php/image/Dockerfile
+++ b/examples/php/image/Dockerfile
@@ -3,4 +3,5 @@ ADD swarm-client.jar /lib/
 RUN apt-get -y update && apt-get -y install git openjdk-7-jre openjdk-7-jdk wget && apt-get clean
 RUN curl -sS https://getcomposer.org/installer | php && mv composer.phar /usr/local/bin/composer
 RUN wget https://phar.phpunit.de/phpunit-old.phar -O phpunit.phar && chmod +x phpunit.phar && mv phpunit.phar /usr/local/bin/phpunit
-ENTRYPOINT ["java", "-jar", "/lib/swarm-client.jar", "-disableSslVerification", "-master", "http://jenkins:8080", "-labels", "php-slave"]
+ENTRYPOINT ["java", "-jar", "/lib/swarm-client.jar", "-disableSslVerification", "-master", "http://jenkins:8080", "-labels", "php-slave",  "-executors", "1"]
+

--- a/examples/python_slave/image/Dockerfile
+++ b/examples/python_slave/image/Dockerfile
@@ -3,4 +3,4 @@ ADD swarm-client.jar /lib/
 RUN apt-get -y update && apt-get -y install git python-pip openjdk-7-jre  openjdk-7-jdk wget python-dev python3-dev maven && apt-get clean
 RUN pip install tox
 ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64
-ENTRYPOINT ["java", "-jar", "/lib/swarm-client.jar", "-disableSslVerification", "-master", "http://jenkins:8080", "-labels", "python"]
+ENTRYPOINT ["java", "-jar", "/lib/swarm-client.jar", "-disableSslVerification", "-master", "http://jenkins:8080", "-labels", "python", "-executors", "1"]

--- a/examples/ruby/image/Dockerfile
+++ b/examples/ruby/image/Dockerfile
@@ -2,4 +2,4 @@ FROM ruby:2.2.3
 ADD swarm-client.jar /lib/
 RUN apt-get -y update && apt-get -y install git openjdk-7-jre  openjdk-7-jdk wget && apt-get clean
 ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64
-ENTRYPOINT ["java", "-jar", "/lib/swarm-client.jar", "-disableSslVerification", "-master", "http://jenkins:8080", "-labels", "ruby-slave"]
+ENTRYPOINT ["java", "-jar", "/lib/swarm-client.jar", "-disableSslVerification", "-master", "http://jenkins:8080", "-labels", "ruby-slave", "-executors", "1"]


### PR DESCRIPTION
By default the slave offers as many Jenkins
executors as cores are available. But we only
want each container to run one build at a time.
