### PR TITLE
Update Python Slave

### DIFF
--- a/examples/python_slave/basic-config-rc.yaml
+++ b/examples/python_slave/basic-config-rc.yaml
@@ -1,17 +1,40 @@
 ---
-  metadata: 
-    name: "my-cloud-sdk-python-slave-rc"
+  metadata:
+    name: "python35-slave"
   apiVersion: "v1"
   kind: "ReplicationController"
-  spec: 
-    template: 
-      metadata: 
+  spec:
+    template:
+      metadata:
         name: "jenkins-slave"
-        labels: 
+        labels:
           role: "slave"
-      spec: 
-        containers: 
-          - 
-            name: "jenkins-slave"
-            image: "waprin/jenkins-cloud-sdk-python-slave"
+          language: python35
+      spec:
+        containers:
+          -
+            name: "jenkins-python-slave"
+            image: "waprin/jenkins_python_slave"
             imagePullPolicy: "Always"
+            volumeMounts:
+              - mountPath: /var/run/docker.sock
+                name: docker-sock
+              - mountPath: /usr/bin/docker
+                name: docker-bin
+              - mountPath: /tmp
+                name: docker-tmp
+              - name: gcloud-service-account
+                mountPath: /etc/gcloud-service-account
+        volumes:
+            - name: docker-sock
+              hostPath:
+                path: /var/run/docker.sock
+            - name: docker-bin
+              hostPath:
+                path: /usr/bin/docker
+            - name: docker-tmp
+              hostPath:
+                path: /tmp
+            - name: gcloud-service-account
+              secret:
+                secretName: gcloud-service-account

--- a/examples/python_slave/image/Dockerfile
+++ b/examples/python_slave/image/Dockerfile
@@ -5,9 +5,13 @@ RUN apt-get -y update && \
     apt-get -y install \
         git wget \
         python-pip python-dev python3-dev python3.5 python3.5-dev \
-        openjdk-7-jre openjdk-7-jdk maven && \
+        openjdk-7-jre openjdk-7-jdk maven \
+        libffi-dev libssl-dev libxml2-dev \
+        libxslt1-dev libpq-dev libmysqlclient-dev libcurl4-openssl-dev \
+        libjpeg-dev zlib1g-dev libpng12-dev  python-pyaudio && \
     apt-get clean
+
 ADD swarm-client.jar /lib/
 RUN pip install tox
 ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64
-ENTRYPOINT ["java", "-jar", "/lib/swarm-client.jar", "-disableSslVerification", "-master", "http://jenkins:8080", "-labels", "python", "-executors", "1"]
+ENTRYPOINT ["java", "-jar", "/lib/swarm-client.jar", "-disableSslVerification", "-master", "http://jenkins:8080", "-labels", "python35", "-executors", "1"]


### PR DESCRIPTION
Python was previously using `dpe_slave`, now trying to refactor them. This adds other libs we need to this Python image and mounts Docker socket to RC (still need to switch to deployments).
