### PR TITLE
Add internal service config

### DIFF
--- a/setup/master/internal_service_config.yaml
+++ b/setup/master/internal_service_config.yaml
@@ -1,0 +1,20 @@
+---
+  metadata: 
+    name: "jenkins"
+  kind: "Service"
+  apiVersion: "v1"
+  spec: 
+    ports: 
+      - 
+        name: "webui"
+        port: 8080
+        targetPort: "webui"
+        nodePort: 30001
+      - 
+        name: "slavelistener"
+        port: 50000
+        targetPort: "slavelistener"
+        nodePort: 30000
+    type: "NodePort"
+    selector: 
+      role: "master"


### PR DESCRIPTION
This setups the Jenkins service with a nodePort to the web traffic so that the swarm client can still talk to it even with the web traffic firewalled. The swarm client needs to talk to both Jenkins web interface and Jenkins JNLP port, so if we want external instances talking to both ports, we need NodePorts for both.
